### PR TITLE
Add support for specifying Cloudflare proxy status

### DIFF
--- a/cname.luau
+++ b/cname.luau
@@ -1,3 +1,6 @@
+export type Entry = { content: string, proxied: boolean? } | string
+export type Entries = { [string]: Entry }
+
 return {
 	-- ["project"] = "user.github.io", (project.luau.page CNAME record for user.github.io/project)
 	[""] = "nicell.github.io",
@@ -11,4 +14,4 @@ return {
 	["sentry"] = "grilme99.github.io",
 	["typeforge"] = "typeforge-luau.github.io",
 	["ui-labs"] = "pepeeltoro41.github.io",
-}
+} :: Entries

--- a/cname.luau
+++ b/cname.luau
@@ -1,7 +1,7 @@
-export type Entry = { content: string, proxied: boolean? } | string
-export type Entries = { [string]: Entry }
+export type Entry = { content: string, proxied: boolean }
+export type Entries = { [string]: Entry | string }
 
-return {
+local cname: Entries = {
 	-- ["project"] = "user.github.io", (project.luau.page CNAME record for user.github.io/project)
 	[""] = "nicell.github.io",
 	["hermes"] = "froststarinteractive.github.io",
@@ -14,4 +14,6 @@ return {
 	["sentry"] = "grilme99.github.io",
 	["typeforge"] = "typeforge-luau.github.io",
 	["ui-labs"] = "pepeeltoro41.github.io",
-} :: Entries
+}
+
+return cname

--- a/scripts/cloudflare.luau
+++ b/scripts/cloudflare.luau
@@ -43,16 +43,16 @@ local function getRecord(name: string): Record?
 	error(`Failed to get record for {name}: {data.errors[1].message}`)
 end
 
-local function addRecord(name: string, content: string)
+local function addRecord(name: string, content: string, proxy: boolean)
 	table.insert(batch.posts, {
 		type = "CNAME",
 		name = qualifiedName(name),
 		content = content,
-		proxied = true,
+		proxied = proxy,
 	})
 end
 
-local function updateRecord(name: string, content: string)
+local function updateRecord(name: string, content: string, proxy: boolean)
 	local record = getRecord(name)
 	if record == nil then
 		print("Record not found for", name)
@@ -63,7 +63,7 @@ local function updateRecord(name: string, content: string)
 		type = "CNAME",
 		name = qualifiedName(name),
 		content = content,
-		proxied = true,
+		proxied = proxy,
 	})
 end
 

--- a/scripts/update.luau
+++ b/scripts/update.luau
@@ -10,20 +10,35 @@ if not success then
 	oldCname = {}
 end
 
+local function intoEntry(content: string | cname.Entry): cname.Entry
+	if typeof(content) == "string" then
+		-- unstructured CNAME content, always proxied
+		return { content = content, proxied = true }
+	end
+
+	if content.proxied == nil then
+		-- proxied might not be set, default to true
+		content.proxied = true
+	end
+
+	-- structured entry
+	return content
+end
+
 local delete = table.clone(oldCname)
 local add = {}
 local update = {}
 
 for name, content in cname do
-  local entry = if typeof(content) == "string" then { content = content, proxied = true } else content
+	local entry = intoEntry(content)
 
-  if oldCname[name] == nil then
+	if oldCname[name] == nil then
 		add[name] = entry -- net new
 	else
 		delete[name] = nil -- exists in new, not deleted
-		
-    local oldEntry = oldCname[name]
-    if oldEntry.content ~= entry.content or oldEntry.proxied ~= entry.proxied then
+
+		local oldEntry = intoEntry(oldCname[name])
+		if oldEntry.content ~= entry.content or oldEntry.proxied ~= entry.proxied then
 			update[name] = entry -- entry changed
 		end
 	end

--- a/scripts/update.luau
+++ b/scripts/update.luau
@@ -2,7 +2,7 @@ local cf = require("./cloudflare")
 
 local cname = require("../cname")
 local success, oldCname = pcall(function()
-	return require("../cname-old")
+	return require("../cname-old") :: cname.Entries
 end)
 
 if not success then
@@ -15,24 +15,28 @@ local add = {}
 local update = {}
 
 for name, content in cname do
-	if oldCname[name] == nil then
-		add[name] = content -- net new
+  local entry = if typeof(content) == "string" then { content = content, proxied = true } else content
+
+  if oldCname[name] == nil then
+		add[name] = entry -- net new
 	else
 		delete[name] = nil -- exists in new, not deleted
-		if oldCname[name] ~= content then
-			update[name] = content -- content changed
+		
+    local oldEntry = oldCname[name]
+    if oldEntry.content ~= entry.content or oldEntry.proxied ~= entry.proxied then
+			update[name] = entry -- entry changed
 		end
 	end
 end
 
-for name, content in add do
+for name, entry in add do
 	print("add", name)
-	cf.addRecord(name, content)
+	cf.addRecord(name, entry.content, entry.proxied)
 end
 
-for name, content in update do
+for name, entry in update do
 	print("update", name)
-	cf.updateRecord(name, content)
+	cf.updateRecord(name, entry.content, entry.proxied)
 end
 
 for name, _ in delete do

--- a/scripts/update.luau
+++ b/scripts/update.luau
@@ -2,7 +2,7 @@ local cf = require("./cloudflare")
 
 local cname = require("../cname")
 local success, oldCname = pcall(function()
-	return require("../cname-old") :: cname.Entries
+	return require("../cname-old") :: cname.Entries?
 end)
 
 if not success then

--- a/scripts/update.luau
+++ b/scripts/update.luau
@@ -16,11 +16,6 @@ local function intoEntry(content: string | cname.Entry): cname.Entry
 		return { content = content, proxied = true }
 	end
 
-	if content.proxied == nil then
-		-- proxied might not be set, default to true
-		content.proxied = true
-	end
-
 	-- structured entry
 	return content
 end


### PR DESCRIPTION
The `proxied` request body field for Cloudflare API requests is no longer hardcoded to true. 

Each value in `cname.luau` file can now either be a string (as before) or a typed table which contains the record content and a `proxied` boolean. If undefined, or a only a string is used, it defaults to proxying the record.

Two new types (`Entry` and `Entries`) have been exported from the file as well. These have been used for typing the table containing the old CNAMEs in `scripts/update.luau`.

**This code has not been tested, since it is simple enough.**